### PR TITLE
Constraining clean target to source tree

### DIFF
--- a/makefile
+++ b/makefile
@@ -94,27 +94,10 @@ cssfield$(EXE):          cssfield.o
 fo_serve.cgi:          fo_serve.o $(OBJS)
 	$(CC) -o fo_serve.cgi fo_serve.o $(OBJS) $(LIBS)
 
-IDIR=$(HOME)/.find_orb
-
 clean:
 	$(RM) $(OBJS) fo.o findorb.o fo_serve.o find_orb$(EXE) fo$(EXE)
 	$(RM) fo_serve.cgi eph2tle.o eph2tle$(EXE) cssfield$(EXE)
 	$(RM) cssfield.o
-	cd $(IDIR)
-	$(RM) covar.txt covar?.txt debug.txt eleme?.txt elements.txt
-	$(RM) ephemeri.txt gauss.out guide.txt guide?.txt monte.txt monte?.txt
-	$(RM) mpc_f?.txt mpc_fmt.txt mpc_s?.txt mpec.htm obser?.txt observe.txt
-	$(RM) residual.txt sr_el?.txt state.txt state?.txt virtu?.txt virtual.txt
-	$(RM) sr_elems.txt mpcorb.dat
-
-clean_temp:
-	cd $(IDIR)
-	$(RM) covar.txt covar?.txt debug.txt eleme?.txt elements.txt
-	$(RM) ephemeri.txt gauss.out guide.txt guide?.txt monte.txt monte?.txt
-	$(RM) mpc_f?.txt mpc_fmt.txt mpc_s?.txt mpec.htm obser?.txt observe.txt
-	$(RM) residual.txt sr_el?.txt state.txt state?.txt virtu?.txt virtual.txt
-	$(RM) sr_elems.txt mpcorb.dat
-	$(RM) sof?.txt sof1s?.txt
 
 install:
 	-cp find_orb $(HOME)/bin


### PR DESCRIPTION
Hello,
the clean just failed since the find_orb directory did not yet exist in my home directory. It is somewhat unexpected to see a clean target act outside the source tree. This would be an unexpected behaviour. Further, every line is executed in a new shell command, at least with UNIX, which is why the "cd" command has no effect on the lines below. So I expect the very unexpected with that code and have minimised to what is just removing files created at build time.