### PR TITLE
Add support for Docker

### DIFF
--- a/DOWNLOAD.sh
+++ b/DOWNLOAD.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# This script will download find_orb's dependencies into DOWNLOAD_DIR.
+# DOWNLOAD_DIR should be the same directory where the find_orb
+# repository was downloaded such that:
+# ls DOWNLOAD_DIR
+#   find_orb
+#
+# After running this script DOWNLOAD_DIR should look as follows:
+# ls DOWNLOAD_DIR
+#   find_orb
+#   jpl_eph
+#   lunar
+#   miscell
+#   sat_code
+
+usage () { 
+    echo "Usage: /bin/bash DOWNLOAD.sh -d {DOWNLOAD_DIR}"
+    echo "-d DOWNLOAD_DIR [REQUIRED]"
+    echo "    Path to directory in which to download find_orb's dependencies."
+    echo "    Should be the same top-level directory where find_orb repository was downloaded."
+    exit 1
+}
+
+# Add argument catches, if arguments are not recognized run usage function
+dir_flag=false
+while getopts ":d:" opt; do
+  case $opt in
+    d) dir="$OPTARG"; dir_flag=true;;
+    \?) echo "Invalid argument -$OPTARG" >&2; usage;
+  esac
+done
+
+# Make sure the download directory is passed
+if [ "$dir_flag" = false ]
+then
+    usage
+fi
+
+# Create list of repositories
+repos=("lunar" "jpl_eph" "sat_code" "miscell")
+
+# If the repositories have not been downloaded, download them. 
+echo "Cloning required repositories."
+for repo in "${repos[@]}"; do
+    if [ ! -d ../$repo ]
+    then
+        git clone https://github.com/Bill-Gray/$repo.git $dir/$repo 
+    else
+        echo "$repo repository already exists in $dir"
+    fi
+done
+exit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:latest
+MAINTAINER Bill Gray 
+
+SHELL ["/bin/bash", "-c"]
+ENV PATH="${PATH}:~/bin"
+
+# Update applications and install OS-level dependencies
+RUN apt-get update \
+	&& apt-get upgrade -y \
+	&& apt-get install g++ make wget libncurses5-dev libcurl4-openssl-dev git -y
+
+# Download and install find_orb and dependencies
+RUN mkdir software && cd software \
+	&& git clone https://github.com/Bill-Gray/find_orb.git \
+	&& cd find_orb \
+	&& /bin/bash DOWNLOAD.sh -d .. \
+	&& /bin/bash INSTALL.sh -d .. -u

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# This script will build and compile find_orb and its dependencies.
+
+usage () { 
+    echo "Usage: /bin/bash INSTALL.sh -d {DOWNLOAD_DIR}"
+    echo "-d DOWNLOAD_DIR [REQUIRED]"
+    echo "    Path to directory where find_orb and its dependencies were downloaded."
+    echo "-u UPDATE [OPTIONAL]"
+    echo "    Check find_orb's dependencies for updates and pull them."
+    exit 1
+}
+
+# Add argument catches, if arguments are not recognized run usage function
+dir_flag=false
+update_flag=false
+while getopts ":d:u" opt; do
+  case $opt in
+    d) dir="$OPTARG"; dir_flag=true;;
+    u) update_flag=true;;
+    \?) echo "Invalid argument -$OPTARG" >&2; usage;
+  esac
+done
+
+# Make sure the download directory is passed
+if [ "$dir_flag" = false ]
+then
+    usage
+fi
+
+# Create list of repositories
+repos=("lunar" "jpl_eph" "sat_code" "miscell")
+
+# Make sure the supporting repos have been downloaded.
+# If they have and the update flag has been triggered, 
+# then pull the latest updates
+for repo in "${repos[@]}"; do
+    if [ ! -d $dir/$repo ]
+    then
+        echo "Could not find the $repo repository!"
+        exit 1
+    else
+        if [ "$update_flag" = true ]
+        then
+            cd $dir/$repo && git pull origin master
+        fi
+    fi
+done
+
+echo "Building find_orb and its dependencies."
+# Make each dependency and find_orb
+
+cd $dir/lunar \
+    && make clean \
+    && make \
+    && make install 
+cd $dir/jpl_eph \
+    && make clean \
+    && make libjpl.a \
+    && make install 
+cd $dir/lunar \
+    && make integrat 
+cd $dir/sat_code \
+    && make clean \
+    && make sat_id \
+    && make install 
+cd $dir/find_orb \
+    && make clean \
+    && make \
+    && make install 
+
+# Download DE430 if it hasn't already been downloaded.
+JPL_EPH_FILE=~/.find_orb/linux_p1550p2650.430t
+if [ ! -f "$JPL_EPH_FILE" ]; then 
+    cd ~/.find_orb \
+        && wget ftp://ssd.jpl.nasa.gov/pub/eph/planets/Linux/de430t/linux_p1550p2650.430t
+fi
+
+# Add executables to PATH
+export PATH="$PATH:~/bin"
+exit 

--- a/UNINSTALL.sh
+++ b/UNINSTALL.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Removes binaries, header files, data files installed by 
+# find_orb and optionally the git repositories of its dependencies.
+
+usage () { 
+    echo "Usage: /bin/bash UNINSTALL.sh -d {DOWNLOAD_DIR}"
+    echo "-d DOWNLOAD_DIR [REQUIRED]"
+    echo "    Path to directory where find_orb and its dependencies were downloaded."
+    echo "-g REMOVE_GIT [OPTIONAL]"
+    echo "    Remove git repositories of find_orb's dependencies."
+    exit 1
+}
+
+# Add argument catches, if arguments are not recognized run usage function
+dir_flag=false
+repo_flag=false
+while getopts ":d:g" opt; do
+  case $opt in
+    d) dir="$OPTARG"; dir_flag=true;;
+    g) repo_flag=true;;
+    \?) echo "Invalid argument -$OPTARG" >&2; usage;
+  esac
+done
+
+# Make sure the download directory is passed
+if [ "$dir_flag" = false ]
+then
+    usage
+fi
+
+BIN=~/bin
+INCLUDE=~/include
+LIB=~/lib
+
+echo "Uninstalling find_orb."
+rm -rf -v ~/.find_orb
+
+# Remove binaries from ~/bin/
+array=("astcheck" "find_orb" "fo" "sat_id")
+for i in "${array[@]}"
+do
+    if [ -f $BIN/$i ]; then
+        rm -v $BIN/$i
+    else
+        echo "$i has already been removed."
+    fi
+done
+
+# Remove header files from ~/include/
+array=("afuncs.h" "cgi_func.h" "date.h" "jpleph.h" \
+       "mpc_func.h" "showelem.h" "watdefs.h" \
+       "brentmin.h" "comets.h" "get_bin.h" \
+       "lunar.h" "norad.h" "vislimit.h")
+for i in "${array[@]}"
+do
+    if [ -f $INCLUDE/$i ]; then
+        rm -v $INCLUDE/$i
+    else
+        echo "$i has already been removed."
+    fi
+done
+
+# Remove supporting libraries
+array=("libjpl.a" "liblunar.a" "libsatell.a")
+for i in "${array[@]}"
+do
+    if [ -f $LIB/$i ]; then
+        rm -v $LIB/$i
+    else
+        echo "$i has already been removed."
+    fi
+done
+
+# If desired, remove git repositories
+repos=("lunar" "jpl_eph" "sat_code" "miscell")
+if [ "$repo_flag" = true ]; then
+    for repo in "${repos[@]}"; do
+        if [ -d $dir/$repo ]
+        then
+            echo "Removing $repo..."
+            rm -rf -v $dir/$repo
+        else
+            echo "$repo repository has already been removed."
+        fi
+    done
+fi
+exit


### PR DESCRIPTION
Hey Bill,

This pull request adds three shell scripts to help manage the download, install, and uninstall of find_orb and its dependencies. I've also added a Dockerfile which tells docker how to build a container in which find_orb can run. 

**For the shell scripts:**
After a user has downloaded this repository they can download the lunar, miscell, jpl_eph, and sat_code repositories with:
`/bin/bash DOWNLOAD.sh -d ..`
Once that is done, everything can be built and compiled with:
`/bin/bash INSTALL.sh -d .. -u`
And lastly, if find_orb needs to be uninstalled:
`/bin/bash  UNINSTALL.sh -d .. -g`

**For docker:**
After a user has downloaded this repository, they can also build a docker container with: 
`docker image build -t find_orb:latest .` 

One thing to note: this command will only complete successfully once the Dockerfile and the shell scripts are included on find_orb's master. The Dockerfile uses the INSTALL.sh and DOWNLOAD.sh shell scripts to keep the installation process confined to a single set of files.

With the image built, a container with find_orb ready to go can be run with:
`docker container run -it find_orb:latest` 

In the container, find_orb's executables are already added to the path and so can be run immediately. For example:
```
┌─(base)[moeyensj][docker ?:1 ✗][~/repos/forked/find_orb/find_orb]
└─▪ docker container run -it --rm find_orb:dev
root@ef34340e0d2f:/# fo  
'fo' needs the name of an input file of MPC-formatted
astrometry as a command-line argument.
```

Let me know your thoughts, questions, or concerns. Another thing that might be good to look into would be creating an account on https://hub.docker.com/ and then linking this repository with your account on there. That way find_orb can be run in a container without needing to download this repository. 