### PR TITLE
Use mktemp to generate temp_obs files

### DIFF
--- a/miscell.cpp
+++ b/miscell.cpp
@@ -380,10 +380,11 @@ single dummy observation is made that reflects the object's position
 at the epoch (see above 'make_fake_astrometry()' function).  */
 
 #ifndef _WIN32
-const char *temp_obs_filename = "/tmp/temp_obs.txt";
+char tempform[] = "/tmp/temp_obs.XXXXXX";
 #else
-const char *temp_obs_filename = "temp_obs.txt";
+char tempform[] = "temp_obs.XXXXXX";
 #endif
+char *temp_obs_filename = mktemp(tempform);
 
 int reset_astrometry_filename( int *argc, const char **argv)
 {


### PR DESCRIPTION
While working on multiprocessing the `fo` Python subprocess wrappers, I was getting errors that the /tmp/mpc_obs.txt file was missing for some of the concurrently running processes. It turns out each `fo` process was working on the same temporary observation file which was causing issues. 

Here is an example from my Python wrapper, the second statement is a stderr output from `fo`: 
```
(pid=135436) Find_Orb call complete.
(pid=135436) Couldn't locate the file '/tmp/temp_obs.txt'
```
This PR contains a relatively simple fix to randomly generate a temp_obs file using a template string. This fix avoids the issue with multiple threads working on the sample temporary file. I have tested the change on my multiprocessed wrapper and thus far have not encountered any more issues. 

Note: the compiler now warns that using `mkstemp` is better than `mktemp`. From my understanding of the code, swapping to `mkstemp` would involve making more changes than I am comfortable making (`mkstemp` creates the temporary file while `mktemp` creates the file's name). 