### PR TITLE
Fix cpp preprocessor short circuit compatibility issue

### DIFF
--- a/getstrex.c
+++ b/getstrex.c
@@ -9,9 +9,16 @@
    #define NCURSES_WIDECHAR 1
    #define HAVE_NCURSESW
 
-   #if defined( __cplusplus) && defined(__has_include) \
-                                    && __has_include( <ncursesw/cursesw.h>)
-      #include <ncursesw/cursesw.h>
+   #if defined( __cplusplus) 
+       #if defined(__has_include)
+           #if __has_include( <ncursesw/cursesw.h>)
+               #include <ncursesw/cursesw.h>
+           #else
+               #include <curses.h>
+           #endif
+       #else
+           #include <curses.h>
+       #endif
    #else
       #include <curses.h>
    #endif


### PR DESCRIPTION
  Hello,
  Tried to make find_orb and had a small glitch because of short circuited notation in preprocessor macros. With this small change the build completed successfully. Thanks for the package! 
  - Nicole

  find_orb/make failed on CentOS Linux release 7.9.2009
  gcc version 4.8.5 20150623 (Red Hat 4.8.5-44) (GCC)
  https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html

  getstrex.c:13:53: error: missing binary operator before token "("
                                     && __has_include( <ncursesw/cursesw.h>)

