### PR TITLE
Solving some build problems due to sprintf deprecation

### DIFF
--- a/b32_eph.cpp
+++ b/b32_eph.cpp
@@ -191,7 +191,7 @@ int create_b32_ephemeris( const char *filename, const double epoch,
    resolution = max_ordinate / 2.e+9;
    ofile = fopen( filename, "wb");
    memset( tbuff, 0, 128);
-   sprintf( tbuff, hdr_fmt, 128, jpl_id,
+   snprintf( tbuff, sizeof(tbuff), hdr_fmt, 128, jpl_id,
             jd_start, ephem_step, n_steps,
             best_interpolation_order( output_array, 2 * n_steps, &max_err),
             resolution, 32, 0);
@@ -206,7 +206,7 @@ int create_b32_ephemeris( const char *filename, const double epoch,
    free( output_array);
    add_ephemeris_details( ofile, jd_start, curr_jd);
    fclose( ofile);
-   sprintf( tbuff, "max err: %.3g\nEnd: ", max_err);
+   snprintf( tbuff, sizeof(tbuff),"max err: %.3g\nEnd: ", max_err);
    full_ctime( tbuff + strlen( tbuff), curr_jd, CALENDAR_JULIAN_GREGORIAN);
    generic_message_box( tbuff, "o");
    return( 0);

--- a/elem_out.cpp
+++ b/elem_out.cpp
@@ -404,11 +404,11 @@ static void observation_summary_data( char *obuff, const OBSERVE FAR *obs,
    for( i = n_included = 0; i < n_obs; i++)
       n_included += obs[i].is_included;
    if( options == -1)      /* 'guide.txt' bare-bones format */
-      sprintf( obuff, "%d of %d", n_included, n_obs);
+      snprintf( obuff, sizeof(obuff), "%d of %d", n_included, n_obs);
    else if( (options & ELEM_OUT_ALTERNATIVE_FORMAT) && n_included != n_obs)
-      sprintf( obuff, get_find_orb_text( 15), n_included, n_obs);
+      snprintf( obuff, sizeof(obuff), get_find_orb_text( 15), n_included, n_obs);
    else
-      sprintf( obuff, get_find_orb_text( 16), n_included);
+      snprintf( obuff, sizeof(obuff), get_find_orb_text( 16), n_included);
    if( options != -1 && n_included)
       {
       const double rms = (options & ELEM_OUT_NORMALIZED_MEAN_RESID) ?
@@ -428,7 +428,7 @@ static void observation_summary_data( char *obuff, const OBSERVE FAR *obs,
          strlcat_err( rms_buff, " sigmas", sizeof( rms_buff));
       else
          text_search_and_replace( rms_buff, ".", "\".");
-      sprintf( obuff, get_find_orb_text( 17), rms_buff);
+      snprintf( obuff, sizeof(obuff), get_find_orb_text( 17), rms_buff);
       }                                 /* "; mean residual %s." */
 }
 
@@ -527,21 +527,21 @@ static int elements_in_mpcorb_format( char *buff, const char *packed_desig,
    char packed_desig2[40];
 
    packed_desig_minus_spaces( packed_desig2, packed_desig);
-   sprintf( buff, "%-8s%5.2f  %4.2f ", packed_desig2, elem->abs_mag,
+   snprintf( buff, sizeof(buff), "%-8s%5.2f  %4.2f ", packed_desig2, elem->abs_mag,
                            asteroid_magnitude_slope_param);
    day = (int)( decimal_day_to_dmy( elem->epoch, &year,
                               &month, CALENDAR_JULIAN_GREGORIAN) + .0001);
-   sprintf( buff + 20, "%c%02ld%X%c",
+   snprintf( buff + 20, sizeof(buff), "%c%02ld%X%c",
                   int_to_mutant_hex_char( year / 100),
                   year % 100L, month,
                   int_to_mutant_hex_char( day));
-   sprintf( buff + 25, "%10.5f%11.5f%11.5f%11.5f%11.7f",
+   snprintf( buff + 25, sizeof(buff), "%10.5f%11.5f%11.5f%11.5f%11.7f",
            centralize_ang( elem->mean_anomaly) * 180. / PI,
            centralize_ang( elem->arg_per) * 180. / PI,
            centralize_ang( elem->asc_node) * 180. / PI,
            centralize_ang( elem->incl) * 180. / PI,
            elem->ecc);
-   sprintf( buff + 79, "%12.8f%12.7f",
+   snprintf( buff + 79, sizeof(buff), "%12.8f%12.7f",
             (180 / PI) / elem->t0,        /* n */
             elem->major_axis);
    for( i = 0; i < n_obs; i++)
@@ -549,35 +549,35 @@ static int elements_in_mpcorb_format( char *buff, const char *packed_desig,
          n_included_obs++;
    day = (int)( decimal_day_to_dmy( current_jd( ),
                          &year, &month, CALENDAR_JULIAN_GREGORIAN) + .0001);
-   sprintf( buff + 103,
+   snprintf( buff + 103, sizeof(buff),
       "    FO %02d%02d%02d  %4d  %2d ****-**** ****         Find_Orb   %04x",
                   (int)( year % 100), month, (int)day,
                   n_included_obs, n_oppositions, hex_flags);
    get_first_and_last_included_obs( obs, n_obs, &first_idx, &last_idx);
    arc_length = obs[last_idx].jd - obs[first_idx].jd;
    if( arc_length < 99. / seconds_per_day)
-      sprintf( buff + 127, "%4.1f sec ", arc_length * seconds_per_day);
+      snprintf( buff + 127, sizeof(buff), "%4.1f sec ", arc_length * seconds_per_day);
    else if( arc_length < 99. / minutes_per_day)
-      sprintf( buff + 127, "%4.1f min ", arc_length * minutes_per_day);
+      snprintf( buff + 127, sizeof(buff), "%4.1f min ", arc_length * minutes_per_day);
    else if( arc_length < 2.)
-      sprintf( buff + 127, "%4.1f hrs ", arc_length * hours_per_day);
+      snprintf( buff + 127, sizeof(buff), "%4.1f hrs ", arc_length * hours_per_day);
    else if( arc_length < 600.)
-      sprintf( buff + 127, "%4d days", (int)arc_length + 1);
+      snprintf( buff + 127, sizeof(buff), "%4d days", (int)arc_length + 1);
    else
-      sprintf( buff + 127, "%4d-%4d",
+      snprintf( buff + 127, sizeof(buff), "%4d-%4d",
                 (int)JD_TO_YEAR( obs[first_idx].jd),
                 (int)JD_TO_YEAR( obs[last_idx].jd));
    buff[136] = ' ';
-   sprintf( buff + 165, " %-30s", full_desig);
+   snprintf( buff + 165, sizeof(buff), " %-30s", full_desig);
    day = (int)( decimal_day_to_dmy( obs[last_idx].jd, &year,
                        &month, CALENDAR_JULIAN_GREGORIAN) + .0001);
-   sprintf( buff + 194, "%04ld%02d%02d", year, month, day);
+   snprintf( buff + 194, sizeof(buff), "%04ld%02d%02d", year, month, day);
    if( rms_err < 9.9)
-      sprintf( buff + 137, "%4.2f", rms_err);
+      snprintf( buff + 137, sizeof(buff), "%4.2f", rms_err);
    else if( rms_err < 99.9)
-      sprintf( buff + 137, "%4.1f", rms_err);
+      snprintf( buff + 137, sizeof(buff), "%4.1f", rms_err);
    else if( rms_err < 9999.)
-      sprintf( buff + 137, "%4.0f", rms_err);
+      snprintf( buff + 137, sizeof(buff), "%4.0f", rms_err);
    buff[141] = ' ';
    if( (perturbers & 0x1fe) == 0x1fe)
       {    /* we have Mercury through Neptune,  at least */
@@ -797,7 +797,7 @@ static char *object_name( char *buff, const int obj_index)
    else if( obj_index > 0 && obj_index < 11) /* nine planets & moon */
       strcpy( buff, get_find_orb_text( 99107 + obj_index));
    else
-      sprintf( buff, "Object_%d\n", obj_index);
+      snprintf( buff, sizeof(buff), "Object_%d\n", obj_index);
    return( buff);
 }
 
@@ -1136,7 +1136,7 @@ static int elements_in_guide_format( char *buff, const ELEMENTS *elem,
    day = decimal_day_to_dmy( elem->perih_time, &year, &month,
                                               CALENDAR_JULIAN_GREGORIAN);
             /*      name day  mon yr MA      q      e */
-   sprintf( buff, "%-43s%8.5f%3d%5ld Find_Orb %14.7f%12.7f%11.6f%12.6f%12.6f",
+   snprintf( buff, sizeof(buff), "%-43s%8.5f%3d%5ld Find_Orb %14.7f%12.7f%11.6f%12.6f%12.6f",
             obj_name, day, month, year,
             elem->q, elem->ecc,
             centralize_ang( elem->incl) * 180. / PI,
@@ -1144,15 +1144,15 @@ static int elements_in_guide_format( char *buff, const ELEMENTS *elem,
             centralize_ang( elem->asc_node) * 180. / PI);
    if( elem->q < .01)
       {
-      sprintf( buff + 71, "%12.10f", elem->q);
+      snprintf( buff + 71, sizeof(buff), "%12.10f", elem->q);
       buff[71] = buff[83] = ' ';
       }
-   sprintf( buff + strlen( buff), " %9.1f%5.1f%5.1f %c",
+   snprintf( buff + strlen( buff), sizeof(buff), " %9.1f%5.1f%5.1f %c",
             elem->epoch, elem->abs_mag,
             elem->slope_param * (elem->is_asteroid ? 1. : 0.4),
             (elem->is_asteroid ? 'A' : ' '));
    if( elem->central_obj)
-      sprintf( buff + strlen( buff), "  Center: %d", elem->central_obj);
+      snprintf( buff + strlen( buff), sizeof(buff), "  Center: %d", elem->central_obj);
    strcat( buff, "  ");
    observation_summary_data( buff + strlen( buff), obs, n_obs, -1);
    return( 0);
@@ -1613,7 +1613,7 @@ void rotate_state_vector_to_current_frame( double *state_vect,
          if( !year)
              year = JD_TO_YEAR( epoch_shown);
          if( body_frame_note)
-            sprintf( body_frame_note, "(%s)", elem_epoch);
+            snprintf( body_frame_note,  sizeof(body_frame_note), "(%s)", elem_epoch);
          setup_ecliptic_precession( precession_matrix, 2000., year);
          precess_vector( precession_matrix, state_vect, state_vect);
          precess_vector( precession_matrix, state_vect + 3, state_vect + 3);
@@ -1752,6 +1752,7 @@ int write_out_elements_to_file( const double *orbit,
             const int options)
 {
    char object_name[80], buff[260], more_moids[80];
+   const size_t buff_size = 260;
    const char *file_permits = (append_elements_to_element_file ? "tfca" : "tfcw+");
    extern const char *elements_filename;
    FILE *ofile = fopen_ext( get_file_name( buff, elements_filename), file_permits);
@@ -1825,7 +1826,7 @@ int write_out_elements_to_file( const double *orbit,
    elem.epoch = epoch_shown;
    calc_classical_elements( &elem, rel_orbit, epoch_shown, 1);
    if( elem.ecc < .9)
-      sprintf( orbit_summary_text, "a=%.3f, ", elem.major_axis);
+      snprintf( orbit_summary_text,  sizeof(orbit_summary_text), "a=%.3f, ", elem.major_axis);
    else
       *orbit_summary_text = '\0';
    if( elem.ecc >= .9 || (orbit_summary_options & ORBIT_SUMMARY_Q))
@@ -1919,18 +1920,18 @@ int write_out_elements_to_file( const double *orbit,
 
                if( mass)
                   {
-                  sprintf( tt_ptr, "; %s=%.4g", constraints, *mass);
+                  snprintf( tt_ptr, sizeof(tt_ptr), "; %s=%.4g", constraints, *mass);
                   consider_replacing( buff, constraints, "Sigma_mass:");
                   clobber_leading_zeroes_in_exponent( buff);
                   }
                else
-                  sprintf( tt_ptr, "; bad '%s'", constraints);
+                  snprintf( tt_ptr, sizeof(tt_ptr), "; bad '%s'", constraints);
                }
             else
-               sprintf( tt_ptr, ";  Constraint: %s", constraints);
+               snprintf( tt_ptr, sizeof(tt_ptr), ";  Constraint: %s", constraints);
             }
          else if( n_monte_carlo_impactors && monte_carlo)
-            sprintf( tt_ptr, ";  %.2f%% impact (%d/%d)",
+            snprintf( tt_ptr, sizeof(tt_ptr), ";  %.2f%% impact (%d/%d)",
                 100. * (double)n_monte_carlo_impactors /
                        (double)monte_carlo_object_count,
                        n_monte_carlo_impactors, monte_carlo_object_count);
@@ -1955,7 +1956,7 @@ int write_out_elements_to_file( const double *orbit,
                put_double_in_buff( tbuff0, orbit[j + 6]);
                text_search_and_replace( tbuff0, " ", "");
                strlcat_error( tbuff0, " ");
-               sprintf( sig_name, "Sigma_A%d:", j + 1);
+               snprintf( sig_name, sizeof(sig_name), "Sigma_A%d:", j + 1);
                if( showing_sigmas)
                   if( !get_uncertainty( sig_name, sigma_buff + 4, false))
                      strlcat_error( tbuff0, sigma_buff);
@@ -1996,7 +1997,7 @@ int write_out_elements_to_file( const double *orbit,
 
          if( force_model == FORCE_MODEL_SRP)
             {
-            sprintf( tt_ptr, "; AMR %.5g",
+            snprintf( tt_ptr, sizeof(tt_ptr), "; AMR %.5g",
                                  orbit[6] * SOLAR_GM / SRP1AU);
             if( showing_sigmas)
                consider_replacing( tt_ptr, "AMR", "Sigma_AMR:");
@@ -2032,7 +2033,7 @@ int write_out_elements_to_file( const double *orbit,
                            "Ve", "Me", "Ma", "Sa", "Ur", "Ne",
                            "Ce", "Pa", "Vt", "(29)", "(16)", "(15)" };
 
-                  sprintf( addendum, "   %s: %.4f", moid_text[j], moid);
+                  snprintf( addendum, sizeof(addendum), "   %s: %.4f", moid_text[j], moid);
                   if( strlen( addendum) + strlen( buff) < 79)
                      strlcat_error( buff, addendum);
                   else
@@ -2063,7 +2064,7 @@ int write_out_elements_to_file( const double *orbit,
          if( !memcmp( buff + 31, " G ", 3) && uncertainty_parameter < 90.)
             {                       /* replace slope w/uncertainty */
 //          sprintf( buff + 32, "U%7.3f  ", uncertainty_parameter);
-            sprintf( buff + 32, "U%5.1f  ", uncertainty_parameter);
+            snprintf( buff + 32, buff_size - 32, "U%5.1f  ", uncertainty_parameter);
             buff[40] = ' ';
             }
       if( showing_sigmas)
@@ -2371,7 +2372,7 @@ int write_out_elements_to_file( const double *orbit,
                      /* "conventional" East/West 0-180 degree format:  */
          if( elem.central_obj == 3)
             {
-            sprintf( end_ptr, "%c%.5f",
+            snprintf( end_ptr, sizeof(end_ptr), "%c%.5f",
                   (lon < 180. ? 'E' : 'W'),
                   (lon < 180. ? lon : 360. - lon));
             fprintf( ofile, "%s at %s\n", (is_an_impact ? "IMPACT" : "LAUNCH"),
@@ -2379,7 +2380,7 @@ int write_out_elements_to_file( const double *orbit,
             }
                      /* Then show in 0-360 format,  for all other  */
                      /* planets, and for output to file:           */
-         sprintf( end_ptr, "%9.5f", lon);
+         snprintf( end_ptr, sizeof(end_ptr), "%9.5f", lon);
          if( elem.central_obj != 3)
             fprintf( ofile, "%s at %s\n", (is_an_impact ? "IMPACT" : "LAUNCH"),
                              impact_buff);
@@ -2405,32 +2406,32 @@ int write_out_elements_to_file( const double *orbit,
       char time_buff[40];
       bool nongrav_sigmas_found = false;
 
-      sprintf( tbuff, "#  $Name=%s", object_name);
+      snprintf( tbuff, sizeof(tbuff), "#  $Name=%s", object_name);
       text_search_and_replace( tbuff + 4, " ", "%20");
                /* Epoch has to be given in YYYYMMDD.DDDDD format: */
       full_ctime( time_buff, helio_elem.perih_time,
                FULL_CTIME_YMD | FULL_CTIME_MONTHS_AS_DIGITS
                | FULL_CTIME_MICRODAYS | FULL_CTIME_LEADING_ZEROES);
       time_buff[4] = time_buff[7] = '\0';
-      sprintf( tbuff + strlen( tbuff), "  $Ty=%s  $Tm=%s  $Td=%s",
+      snprintf( tbuff + strlen( tbuff), sizeof(tbuff), "  $Ty=%s  $Tm=%s  $Td=%s",
                time_buff, time_buff + 5, time_buff + 8);
-      sprintf( tbuff + strlen( tbuff), "  $MA=%.5f",
+      snprintf( tbuff + strlen( tbuff), sizeof(tbuff), "  $MA=%.5f",
                   centralize_ang( helio_elem.mean_anomaly) * 180. / PI);
       fprintf( ofile, "%s\n", tbuff);
 
-      sprintf( tbuff, "#  $ecc=%.7f  $Eqnx=2000.", helio_elem.ecc);
+      snprintf( tbuff, sizeof(tbuff), "#  $ecc=%.7f  $Eqnx=2000.", helio_elem.ecc);
       fprintf( ofile, "%s\n", tbuff);
 
-      sprintf( tbuff, "#  $a=%.7f  $Peri=%.5f  $Node=%.5f",
+      snprintf( tbuff, sizeof(tbuff), "#  $a=%.7f  $Peri=%.5f  $Node=%.5f",
                   helio_elem.major_axis,
                   centralize_ang( helio_elem.arg_per) * 180. / PI,
                   centralize_ang( helio_elem.asc_node) * 180. / PI);
-      sprintf( tbuff + strlen( tbuff), "  $Incl=%.5f",
+      snprintf( tbuff + strlen( tbuff), sizeof(tbuff), "  $Incl=%.5f",
                   helio_elem.incl * 180. / PI);
       fprintf( ofile, "%s\n", tbuff);
 
-      sprintf( tbuff, "#  $EpJD=%.3f  $q=%.6f", helio_elem.epoch, helio_elem.q);
-      sprintf( tbuff + strlen( tbuff), "  $T=%.6f  $H=%.1f",
+      snprintf( tbuff, sizeof(tbuff), "#  $EpJD=%.3f  $q=%.6f", helio_elem.epoch, helio_elem.q);
+      snprintf( tbuff + strlen( tbuff), sizeof(tbuff), "  $T=%.6f  $H=%.1f",
                helio_elem.perih_time, helio_elem.abs_mag);
       fprintf( ofile, "%s\n", tbuff);
       fprintf( ofile, "# Sigmas avail: %d\n", available_sigmas);
@@ -2438,7 +2439,7 @@ int write_out_elements_to_file( const double *orbit,
          {
          char key[20], obuff[50];
 
-         sprintf( key, "Sigma_A%d:", i);
+         snprintf( key, sizeof(key), "Sigma_A%d:", i);
          if( !get_uncertainty( key, obuff, false))
             {
             fprintf( ofile, (nongrav_sigmas_found ? "   %s %s" : "# %s %s"),
@@ -2484,9 +2485,9 @@ int write_out_elements_to_file( const double *orbit,
          element_filename = "mpcorb.dat";
       if( *impact_buff)
          n_monte_carlo_impactors++;
-      sprintf( name_buff, "%05d", n_clones_accepted);
+      snprintf( name_buff, sizeof(name_buff), "%05d", n_clones_accepted);
       packed_desig_minus_spaces( virtual_full_desig, obs->packed_id);
-      sprintf( virtual_full_desig + strlen( virtual_full_desig), " [%d]",
+      snprintf( virtual_full_desig + strlen( virtual_full_desig), sizeof(virtual_full_desig), " [%d]",
                                   monte_carlo_object_count);
       if( elem.central_obj || elem.ecc > .999999)
          {

--- a/findorb.cpp
+++ b/findorb.cpp
@@ -3014,6 +3014,7 @@ static int user_select_file( char *filename, const char *title, const int flags)
 #ifndef __WATCOMC__
    const bool is_save_dlg = (flags & 1);
    char cmd[256];
+   const size_t cmd_size = 256;
    int rval;
    const bool x_is_running = (NULL != getenv( "DISPLAY"));
 
@@ -3050,7 +3051,7 @@ static int user_select_file( char *filename, const char *title, const int flags)
 
          /* dialog and Xdialog take the same options : */
    full_endwin( );
-   sprintf( strchr( cmd, '~'), "~ %d %d",
+   snprintf( strchr( cmd, '~'), cmd_size, "~ %d %d",
                           getmaxy( stdscr) - 15, getmaxx( stdscr) - 3);
    rval = try_a_file_dialog_program( filename, cmd + 1);
    restart_curses( );
@@ -3284,7 +3285,7 @@ static OBJECT_INFO *load_file( char *ifilename, int *n_ids, char *err_buff,
          err_msg = "Couldn't locate the file '%s'\n";
       else
          err_msg = "No objects found in file '%s'\n";
-      sprintf( err_buff, err_msg, ifilename);
+      snprintf( err_buff, sizeof(err_buff), err_msg, ifilename);
       if( ids)
          free( ids);
       ids = NULL;

--- a/fo.cpp
+++ b/fo.cpp
@@ -119,7 +119,7 @@ int inquire( const char *prompt, char *buff, const int max_len,
 
 static void object_comment_text( char *buff, const OBJECT_INFO *id)
 {
-   sprintf( buff, "%d observations; ", id->n_obs);
+   snprintf( buff, sizeof(buff),"%d observations; ", id->n_obs);
    make_date_range_text( buff + strlen( buff), id->jd_start, id->jd_end);
 }
 

--- a/miscell.cpp
+++ b/miscell.cpp
@@ -309,7 +309,7 @@ FILE *fopen_ext( const char *filename, const char *permits)
       {
       char buff[300];
 
-      sprintf( buff, "Error opening %s: %s",
+      snprintf( buff, sizeof(buff), "Error opening %s: %s",
                  filename, strerror( errno));
       generic_message_box( buff, "o");
       exit( -1);

--- a/monte0.cpp
+++ b/monte0.cpp
@@ -313,7 +313,7 @@ char *put_double_in_buff( char *buff, const double ival)
       {
       char *tptr;
 
-      sprintf( buff, format, ival);
+      snprintf( buff, sizeof(buff), format, ival);
       while( (tptr = strchr( buff, 'e')) != NULL
                      &&  tptr[2] == '0')
          {           /* remove a leading zero from exponent */
@@ -322,7 +322,7 @@ char *put_double_in_buff( char *buff, const double ival)
          }
       }
    else
-      sprintf( buff, "%*ld", precision + 7, (long)ival);
+      snprintf( buff, sizeof(buff), "%*ld", precision + 7, (long)ival);
    while( *buff == ' ')
       buff++;
    return( buff);
@@ -403,11 +403,11 @@ double dump_monte_data_to_file( FILE *ofile, const double *sigmas,
          {
          char zbuff[40];
 
-         sprintf( zbuff, "%.8f", sigmas[i]);
+         snprintf( zbuff, sizeof(zbuff), "%.8f", sigmas[i]);
          remove_insignificant_digits( zbuff);
          if( strlen( zbuff) == 10)   /* very low value */
             put_double_in_buff( zbuff, sigmas[i]);
-         sprintf( tbuff, "%10s", zbuff);
+         snprintf( tbuff, sizeof(tbuff), "%10s", zbuff);
          }
       else
          put_double_in_buff( tbuff, sigmas[i]);

--- a/mpc_obs.cpp
+++ b/mpc_obs.cpp
@@ -2371,7 +2371,7 @@ static void inline reformat_rwo_designation_to_mpc( const char *buff, char *obuf
       *obuff = int_to_mutant_hex_char( leading_digit);
       if( !*obuff)      /* mutant hex fails past asteroid 619999 */
          *obuff = '?';  /* ...just put _something_ there         */
-      sprintf( obuff + 1, "%04ld", ast_number % 10000L);
+      snprintf( obuff + 1, sizeof(obuff), "%04ld", ast_number % 10000L);
       obuff[5] = ' ';
       }
    else                       /* provisional designation */
@@ -4919,17 +4919,17 @@ static void reference_to_text( char *obuff, const char *reference,
    else if( !strcmp( reference, "neocp"))
       strcpy( obuff, "NEOCP");
    else if( *reference >= '0' && *reference <= '9')
-      sprintf( obuff, "MPC %s", reference);
+      snprintf( obuff, sizeof(obuff), "MPC %s", reference);
    else if( *reference == '@')
-      sprintf( obuff, "MPC 10%s", reference + 1);
+      snprintf( obuff, sizeof(obuff), "MPC 10%s", reference + 1);
    else if( *reference >= 'a' && *reference <= 'z')
-      sprintf( obuff, "MPS %d%s", *reference - 'a', reference + 1);
+      snprintf( obuff, sizeof(obuff), "MPS %d%s", *reference - 'a', reference + 1);
    else if( *reference == 'E')
       {
       int obs_year, curr_year;
       char obs_letter, curr_letter;
 
-      sprintf( obuff, "MPEC ?  ?-%c%d", reference[1], atoi( reference + 2));
+      snprintf( obuff, sizeof(obuff), "MPEC ?  ?-%c%d", reference[1], atoi( reference + 2));
       obuff[6] = obuff[7] = '?';    /* attempt to evade trigraph oddities */
       obs_year = get_year_and_mpc_half_month_letter( jd, &obs_letter);
       curr_year = get_year_and_mpc_half_month_letter( current_jd( ), &curr_letter);
@@ -4939,17 +4939,17 @@ static void reference_to_text( char *obuff, const char *reference,
          obs_year++;
       if( curr_year == obs_year)    /* this reference can only mean one year: */
          {
-         sprintf( obuff + 5, "%4d", curr_year);
+         snprintf( obuff + 5, sizeof(obuff), "%4d", curr_year);
          obuff[9] = '-';
          }
       }
    else if( *reference == 'D' && isdigit( reference[1]))
-      sprintf( obuff, "DASO %d", atoi( reference + 1));
+      snprintf( obuff, sizeof(obuff), "DASO %d", atoi( reference + 1));
    else if( *reference == '~' || *reference == '#')   /* MPS or MPC number, */
       {                 /* packed as four "mutant hex" (base 62) digits */
       const unsigned number = get_mutant_hex_value( reference + 1, 4);
 
-      sprintf( obuff, "MP%c %u", ((*reference == '~') ? 'S' : 'C'),
+      snprintf( obuff, sizeof(obuff), "MP%c %u", ((*reference == '~') ? 'S' : 'C'),
                         number + ((*reference == '~') ? 260000 : 110000));
       }
    else           /* just copy it in,  but add a space */
@@ -5012,17 +5012,17 @@ static void format_motion( char *obuff, const double motion)
    const double fabs_motion = fabs( motion);
 
    if( fabs_motion < 99.)
-      sprintf( obuff, "%5.2f'/hr", motion);
+      snprintf( obuff, sizeof(obuff), "%5.2f'/hr", motion);
    else if( fabs_motion < 999.)
-      sprintf( obuff, "%5.1f'/hr", motion);
+      snprintf( obuff, sizeof(obuff), "%5.1f'/hr", motion);
    else if( fabs_motion < 99999.)
-      sprintf( obuff, "%5.0f'/hr", motion);
+      snprintf( obuff, sizeof(obuff), "%5.0f'/hr", motion);
    else if( fabs_motion < 99999. * 60.)
-      sprintf( obuff, "%5.0f%c/hr", motion / 60., degree_symbol);
+      snprintf( obuff, sizeof(obuff), "%5.0f%c/hr", motion / 60., degree_symbol);
    else if( fabs_motion < 99999. * 3600.)
-      sprintf( obuff, "%5.0f%c/min", motion / 3600., degree_symbol);
+      snprintf( obuff, sizeof(obuff), "%5.0f%c/min", motion / 3600., degree_symbol);
    else if( fabs_motion < 99999. * 216000.)
-      sprintf( obuff, "%5.0f%c/sec", motion / 216000., degree_symbol);
+      snprintf( obuff, sizeof(obuff), "%5.0f%c/sec", motion / 216000., degree_symbol);
    else
       strcpy( obuff, "!!!!!");
 }
@@ -5133,7 +5133,7 @@ static void show_radar_info( char *buff, const OBSERVE *obs)
    RADAR_INFO rinfo;
 
    compute_radar_info( obs, &rinfo);
-   sprintf( buff, "RTDist (C) %.8fs = %.3f km; Dopp %.8f km/s = %.2f Hz",
+   snprintf( buff, sizeof(buff), "RTDist (C) %.8fs = %.3f km; Dopp %.8f km/s = %.2f Hz",
                rinfo.rtt_comp, rinfo.rtt_comp * SPEED_OF_LIGHT,
                rinfo.doppler_comp * SPEED_OF_LIGHT / rinfo.freq_hz,
                rinfo.doppler_comp);
@@ -5313,11 +5313,11 @@ static int generate_observation_text( const OBSERVE FAR *obs, const int idx,
             snprintf_append( buff, buffsize, "   radial vel %.3f km/s  cross ",
                                       m.radial_vel);
             if( fabs( m.cross_residual) < 9.9)
-               sprintf( tbuff, "%.2f", m.cross_residual);
+               snprintf( tbuff, sizeof(tbuff), "%.2f", m.cross_residual);
             else if( fabs( m.cross_residual) < 99.9)
-               sprintf( tbuff, "%4.1f", m.cross_residual);
+               snprintf( tbuff, sizeof(tbuff), "%4.1f", m.cross_residual);
             else if( fabs( m.cross_residual) < 9999.)
-               sprintf( tbuff, "%4d", (int)m.cross_residual);
+               snprintf( tbuff, sizeof(tbuff), "%4d", (int)m.cross_residual);
             else
                strlcpy_error( tbuff, "!!!!");
             strlcat_err( buff, tbuff, buffsize);

--- a/orb_func.cpp
+++ b/orb_func.cpp
@@ -468,7 +468,7 @@ int integrate_orbitl( long double *orbit, const long double t0, const long doubl
 
          if( runtime_message)
             move_add_nstr( 9, 10, runtime_message, -1);
-         sprintf( buff, "t = %.5f; %.5f to %.5f; step ",
+         snprintf( buff, sizeof(buff), "t = %.5f; %.5f to %.5f; step ",
                  (double)JD_TO_YEAR( t), (double)JD_TO_YEAR( t0), (double)JD_TO_YEAR( t1));
          if( fabsl( stepsize) > .1)
             snprintf_append( buff, sizeof( buff), "%.3f   ", (double)stepsize);
@@ -484,14 +484,14 @@ int integrate_orbitl( long double *orbit, const long double t0, const long doubl
          move_add_nstr( 10, 10, buff, -1);
          prev_n_steps = n_steps;
          real_time = time( NULL);
-         sprintf( buff, " %02d:%02d:%02d; %f; %d cached   ",
+         snprintf( buff, sizeof(buff), " %02d:%02d:%02d; %f; %d cached   ",
                      (int)( (real_time / 3600) % 24L),
                      (int)( (real_time / 60) % 60),
                      (int)( real_time % 60), (double)( t - prev_t),
                      n_posns_cached);
          prev_t = t;
          move_add_nstr( 11, 10, buff, -1);
-         sprintf( buff, "%d steps; %d rejected", n_steps, n_rejects);
+         snprintf( buff, sizeof(buff), "%d steps; %d rejected", n_steps, n_rejects);
          if( best_fit_planet_dist)
             {
             snprintf_append( buff, sizeof( buff), "; center %d, ",
@@ -499,31 +499,31 @@ int integrate_orbitl( long double *orbit, const long double t0, const long doubl
             format_dist_in_buff( buff + strlen( buff), best_fit_planet_dist);
             }
          if( planet_ns)
-            sprintf( buff + strlen( buff), "  tp:%ld.%09ld",
+            snprintf( buff + strlen( buff), sizeof(buff), "  tp:%ld.%09ld",
                   (long)( planet_ns / (int64_t)1000000000),
                   (long)( planet_ns % (int64_t)1000000000));
          strcat( buff, "  ");
          move_add_nstr( 12, 10, buff, -1);
-         sprintf( buff, "last err: %.3e/%.3e  n changes: %d  ",
+         snprintf( buff, sizeof(buff), "last err: %.3e/%.3e  n changes: %d  ",
                         (double)last_err, (double)step_increase, n_changes);
          move_add_nstr( 13, 10, buff, -1);
          if( use_encke)
             {
-            sprintf( buff, "e = %.5f; q = ", ref_orbit.ecc);
+            snprintf( buff, sizeof(buff), "e = %.5f; q = ", ref_orbit.ecc);
             format_dist_in_buff( buff + strlen( buff), ref_orbit.q);
             strcat( buff, "     ");
             move_add_nstr( 18, 10, buff, -1);
             }
-         sprintf( buff, "Pos: %11.6f %11.6f %11.6f",
+         snprintf( buff, sizeof(buff), "Pos: %11.6f %11.6f %11.6f",
                      dorbit[0], dorbit[1], dorbit[2]);
          move_add_nstr( 14, 10, buff, -1);
-         sprintf( buff, "Vel: %11.6f %11.6f %11.6f",
+         snprintf( buff, sizeof(buff), "Vel: %11.6f %11.6f %11.6f",
                      dorbit[3], dorbit[4], dorbit[5]);
          move_add_nstr( 15, 10, buff, -1);
 #ifdef TEST_PLANET_CACHING_HASH_FUNCTION
          if( total_n_searches)
             {
-            sprintf( buff, "%ld searches; avg %.2f max %ld     ",
+            snprintf( buff, sizeof(buff), "%ld searches; avg %.2f max %ld     ",
                             total_n_searches,
                             (double)total_n_probes / (double)total_n_searches,
                             max_probes_required);
@@ -1879,7 +1879,7 @@ int herget_method( OBSERVE FAR *obs, int n_obs, double r1, double r2,
    set_distance( &temp_obs2, r2);
    runtime_message = tstr;
    if( using_pseudo_vaisala)
-      sprintf( tstr, "Vaisala %f\n", obs->solar_r);
+      snprintf( tstr, sizeof(tstr), "Vaisala %f\n", obs->solar_r);
    else
       strcpy( tstr, "H/xfer orbit (1)");
                /* Compute the trial orbit in the local orbit2 array.  That */
@@ -2727,7 +2727,7 @@ int full_improvement( OBSERVE FAR *obs, int n_obs, double *orbit,
                /* We save the input orbit;  if there's an error,  we can */
                /* restore it:         */
    memcpy( original_orbit, orbit, n_orbit_params * sizeof( double));
-   sprintf( tstr, "full improvement: %f  ", JD_TO_YEAR( epoch));
+   snprintf( tstr, sizeof(tstr), "full improvement: %f  ", JD_TO_YEAR( epoch));
    runtime_message = tstr;
    for( i = 0; i < n_obs; i++)
       if( obs->note2 != 'R')
@@ -2769,7 +2769,7 @@ int full_improvement( OBSERVE FAR *obs, int n_obs, double *orbit,
          epoch2 = find_epoch_shown( obs, n_obs);
       }
 
-   sprintf( tstr, "fi/setting locs: %f  ", JD_TO_YEAR( epoch));
+   snprintf( tstr, sizeof(tstr), "fi/setting locs: %f  ", JD_TO_YEAR( epoch));
    fail_on_hitting_planet = true;
    set_locs_rval = set_locs_extended( orbit, epoch, obs, n_obs, epoch2, orbit2);
    fail_on_hitting_planet = saved_fail_on_hitting_planet;
@@ -2824,7 +2824,7 @@ int full_improvement( OBSERVE FAR *obs, int n_obs, double *orbit,
       constraint[n_constraints++] =
               r_mult * (dotted_dist( obs + n_obs - 1) - atof( limited_orbit + 2));
 
-   sprintf( tstr, "fi/locs set: %f  ", JD_TO_YEAR( epoch));
+   snprintf( tstr, sizeof(tstr), "fi/locs set: %f  ", JD_TO_YEAR( epoch));
    for( i = 0; i < n_obs; i++)
       get_residual_data( obs + i, xresids + i, yresids + i);
 
@@ -2876,7 +2876,7 @@ int full_improvement( OBSERVE FAR *obs, int n_obs, double *orbit,
                *asteroid_mass -= delta_val;
             else                    /* adjust position/velocity */
                tweaked_orbit[i] -= delta_val;
-            sprintf( tstr, "Evaluating %d of %d : iter %d   ", i + 1,
+            snprintf( tstr, sizeof(tstr), "Evaluating %d of %d : iter %d   ", i + 1,
                                     n_params, n_iterations);
             if( debug_level > 4)
                debug_printf( "About to set locs #2: delta_val %f\n", delta_val);
@@ -3148,7 +3148,7 @@ int full_improvement( OBSERVE FAR *obs, int n_obs, double *orbit,
                else        /* if( pass == 3) */
                   oval = eigenvectors[j + i * n_params];
                if( pass == 1 || pass == 3)      /* correlation or eigenvects */
-                  sprintf( tbuff, "%10.6f", oval);  /* values are -1 to 1 */
+                  snprintf( tbuff, sizeof(tbuff), "%10.6f", oval);  /* values are -1 to 1 */
                else                             /* covar/WtW values can be */
                   put_double_in_buff( tbuff, oval);   /* huge or tiny */
                fprintf( ofile, "%s", tbuff);
@@ -3176,7 +3176,7 @@ int full_improvement( OBSERVE FAR *obs, int n_obs, double *orbit,
                   for( k = 0; k < (unsigned)n_params; k++)
                      oval += matrix_ptr[i * n_params + k] * matrix_ptr[j * n_params + k];
                   if( pass == 3)      /* eigenvects are normalized; */
-                     sprintf( tbuff, "%10.6f", oval);  /* values are -1 to 1 */
+                     snprintf( tbuff, sizeof(tbuff), "%10.6f", oval);  /* values are -1 to 1 */
                   else                             /* covar/WtW values can be */
                      put_double_in_buff( tbuff, oval);   /* huge or tiny */
                   fprintf( ofile, "%s", tbuff);
@@ -3277,7 +3277,7 @@ int full_improvement( OBSERVE FAR *obs, int n_obs, double *orbit,
          else
             {           /* comet A1, A2, maybe A3 included */
             assert( n_params >= 7);
-            sprintf( title_text, "Sigma_A%d", i - 5);
+            snprintf( title_text, sizeof(title_text), "Sigma_A%d", i - 5);
             }
          fprintf( ofile, "\n%s: %s", title_text, tbuff);
          }
@@ -3329,7 +3329,7 @@ int full_improvement( OBSERVE FAR *obs, int n_obs, double *orbit,
                /* the original version:  */
    if( err_code || is_unreasonable_orbit( orbit))
       debug_printf( "Failed full step: %d: %s\n", err_code, obs->packed_id);
-   sprintf( tstr, "Final setting of orbit    ");
+   snprintf( tstr, sizeof(tstr), "Final setting of orbit    ");
    i = 6;      /* possibly try six half-steps */
    do
       {
@@ -3341,7 +3341,7 @@ int full_improvement( OBSERVE FAR *obs, int n_obs, double *orbit,
          {
          const double after_rms = compute_rms( obs, n_obs);
 
-         sprintf( tstr, "Half-stepping %d\n", 7 - i);
+         snprintf( tstr, sizeof(tstr), "Half-stepping %d\n", 7 - i);
          if( after_rms > before_rms * 1.5 && !limited_orbit)
             {
             for( j = 0; j < n_orbit_params; j++)
@@ -3702,7 +3702,7 @@ static double attempt_improvements( double *orbit, OBSERVE *obs, const int n_obs
             {
             char msg_buff[80];
 
-            sprintf( msg_buff, "%s step: radii %f, %f",
+            snprintf( msg_buff, sizeof(msg_buff), "%s step: radii %f, %f",
                         (method ? "full" : "Herget"),
                         obs[0].r, obs[n_obs - 1].r);
             move_add_nstr( 14, 10, msg_buff, -1);
@@ -4125,7 +4125,7 @@ double initial_orbit( OBSERVE FAR *obs, int n_obs, double *orbit)
 #ifdef CONSOLE
                if( show_runtime_messages)
                   {
-                  sprintf( msg_buff, "Method %d, r=%.4f", i, pseudo_r);
+                  snprintf( msg_buff, sizeof(msg_buff), "Method %d, r=%.4f", i, pseudo_r);
                   move_add_nstr( 14, 10, msg_buff, -1);
                   }
 #endif

--- a/pl_cache.cpp
+++ b/pl_cache.cpp
@@ -624,7 +624,7 @@ int format_jpl_ephemeris_info( char *buff)
    if( !de_version && !jd_start && !jd_end)
       strcpy( buff, get_find_orb_text( 2056));
    else
-      sprintf( buff,
+      snprintf( buff, sizeof(buff),
             "\nUsing %s; covers years %.1f to %.1f\n",
             jpl_get_ephem_name( jpl_eph),
             (jd_start - J2000) / 365.25 + 2000.,


### PR DESCRIPTION
I have substituted the deprecated sprintf by snprintf as suggested by the compiler. As I have learnt later, I could have simply removed the -Werror flag, but now the work is already done and I hope it is useful for others. 

Please check it as this is not my field of expertise. This code compiled in MacOs 12.5.1 and compiler clang-1400.0.29.202 (for Intel chipset, x86_64-apple-darwin21.6.0). However in the Github actions I can see the buildUbuntu failed https://github.com/focanag/find_orb/actions/runs/3517892657/jobs/5896186029 (however it worked for MacOs or Windows). 

Cheers, Paco. 