### PR TITLE
Update environ.def adding T04 to cover all LCO sites (but SOAR)

### DIFF
--- a/environ.def
+++ b/environ.def
@@ -479,7 +479,7 @@ SIGMAS_FILE=
    Note that these 'MPC codes' also have lines in rovers.txt (q.v.).
 GROUP_ATL=M22 T05 T08 W68
 GROUP_LC2=E10 F65
-GROUP_LC1=V37 W85 K91 Q63 Z31 097
+GROUP_LC1=V37 W85 K91 Q63 Z31 097 T04
 
    By default,  astrometric outliers by three sigmas will be rejected.  That's
    set by the following variable.  Set it to 9999999 to cause all observations


### PR DESCRIPTION
Minor change. I just noticed one of the sites was not part of the LC2 of LCO telescopes network. 


V37  elp  McDonald Observatory 
W85  lsc  Cerro Tololo
K91  cpt  Sutherland 
Q63  coj  Siding Spring
Z31  tfn  Tenerife
097  tlv  Wise Observatory
T04  ogg  Haleakala

from https://lco.global/observatory/sites/mpccodes/ . Not added Cerro Pachón, because SOAR access is not as standard.