### PR TITLE
Timing uncertainty for Canberra DSS 47 added to sigma.txt

### DIFF
--- a/sigma.txt
+++ b/sigma.txt
@@ -158,6 +158,7 @@
  256                                     7         1e-9   Green Bank
  257                                     7         1e-9   Goldstone DSS 25, Fort Irwin
  259                                     7         1e-9   EISCAT Tromso UHF
+ d47                                     7         1e-9   Canberra DSS 47
 #  Marco Micheli tells me that (Z84) Calar Alto has been tested
 #  to be good to about 0.05 seconds.  He usually provides positional
 #  uncertainties with the data,  so I'll just specify a 0.1-s timing


### PR DESCRIPTION
Using some radar data I noticed that this station was showing time sigma 1. I have added it to the sigma.txt file, and noticed that many others at the rovers.txt are also missing. However, I think they are only using d47 out of all those non-MPC-code antennas, so we should be good. 