### PR TITLE
Match scope buffer to prevent overflow

### DIFF
--- a/ephem0.cpp
+++ b/ephem0.cpp
@@ -4684,7 +4684,7 @@ static int get_observer_details( const char *observation_filename,
             if( use_lines && !memcmp( buff, "MEA ", 4) && getting_measurers)
                tack_on_names( measurers, buff + 4);
             if( use_lines && !memcmp( buff, "TEL ", 4) && getting_scopes)
-               strlcpy_err( scope, buff + 4, 60);
+               strlcpy_err( scope, buff + 4, 61);
             if( !memcmp( buff, "COD ", 4))
                if( !get_details_from_here( buff, mpc_code, prog_codes))
                   new_code_found = true;


### PR DESCRIPTION

The longest the TEL keyword can be is 59 characters + null terminator. This is not a problem for any telescope in details.txt except for I15, which is 60 characters long and overflows by one letter. This crashes the program.


To reproduce, generate ephemeris for any object in which I15 is involved, such as 2014 FN33. When clicking back, the program will crash:
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/d252d05d-16df-4930-8330-b6e86825bcb8" />

It looks like I15 is the only offending line, maybe there could be an awk check to the GitHub pipeline to prevent from other observatories breaking in the same way, or just making the buffer longer.

cc: @focanag 